### PR TITLE
Make NaN detect example more robust

### DIFF
--- a/nan_detect.py
+++ b/nan_detect.py
@@ -1,14 +1,23 @@
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_flatten
 
 class NanDetect(TorchDispatchMode):
     def __torch_dispatch__(self, func, types, args, kwargs=None):
         kwargs = kwargs or {}
         res = func(*args, **kwargs)
+        flat_res, _ = tree_flatten(res)
 
-        if any(res != res):
-            raise RuntimeError(f"Function {func}(*{args}, **{kwargs}) "
-                               "returned a NaN")
+        for t in flat_res:
+            if not torch.is_tensor(t):
+                continue
+            try:
+                if (t != t).any():
+                    raise RuntimeError(
+                        f"Function {func}(*{args}, **{kwargs}) " "returned a NaN"
+                    )
+            except NotImplementedError:
+                pass
         return res
 
 a = torch.tensor([0.,])


### PR DESCRIPTION
1. We add a `try: ... except NotImplementedError: ...`to handle this case:
```
File "/.../torch/distributed/fsdp/fully_sharded_data_parallel.py", line 773, in forward
    with torch.autograd.profiler.record_function(
  File "/.../torch/autograd/profiler.py", line 519, in __enter__
    self.record = torch.ops.profiler._record_function_enter_new(self.name, self.args)
  File "/.../torch/_ops.py", line 646, in __call__
    return self._op(*args, **kwargs or {})
  File "/.../....py", line 46, in __torch_dispatch__
    if (res != res).any():
NotImplementedError
```
2. We add the `tree_flatten()` in case the output is not a single tensor.
3. We add the `if not torch.is_tensor(t): continue` in case one of the objects returned is not a tensor.