### PR TITLE
Add complex tensor with subclassing

### DIFF
--- a/complex_tensor.py
+++ b/complex_tensor.py
@@ -1,0 +1,57 @@
+import torch
+
+
+class ComplexTensor(torch.Tensor):
+    def __new__(cls, re, im):
+        assert (
+            re.device == im.device
+            and re.layout == im.layout
+            and re.requires_grad == im.requires_grad
+            and re.dtype == im.dtype
+        )
+        res = torch.Tensor._make_wrapper_subclass(  # type: ignore[attr-defined]
+            cls,
+            size=re.size(),
+            strides=re.stride(),  # todo: contiguous only
+            storage_offset=0,
+            dtype=torch.complex64,  # todo: real to complex dtype
+            layout=re.layout,
+            device=re.device,
+            requires_grad=False,  # todo: autograd support
+        )
+        res.re = re
+        res.im = im
+        return res
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if func is torch.ops.aten.mm.default:
+            assert not kwargs
+            x, y = args
+            re = x.re * y.re - x.im * y.im
+            im = x.re * y.im + x.im * y.re
+            return ComplexTensor(re, im)
+        raise NotImplementedError(f"todo {func}")
+
+    def __tensor_flatten__(self):
+        return ["re", "im"], None
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta):
+        assert meta is None
+        re, im = inner_tensors["re"], inner_tensors["im"]
+        return ComplexTensor(re, im)
+
+    def __repr__(self):
+        return f"ComplexTensor(real={self.re}, imag={self.im})"
+
+
+if __name__ == "__main__":
+
+    @torch.compile()
+    def f(x, y):
+        return x @ y
+
+    x = ComplexTensor(torch.tensor([[1]]), torch.tensor([[2]]))
+    y = ComplexTensor(torch.tensor([[3]]), torch.tensor([[4]]))
+
+    print(f(x, y))  # (1 + 2i) * (3 + 4i) = -5 + 10i


### PR DESCRIPTION
Pair-programming with @ezyang at the PyTorch Conference 2023 for a WIP implementation of complex tensors working with `torch.compile`.

The implementation is inspired from https://github.com/pytorch/pytorch/blob/main/torch/testing/_internal/two_tensor.py.

A few todos left, notably a custom autograd for the constructor.

This was tested with the nightly build `2.2.0.dev20231016`.

```shell
> TORCH_LOGS=+aot python complex_tensor.py
FakeTensor(..., size=(1, 1), dtype=torch.int64) FakeTensor(..., size=(1, 1), dtype=torch.int64)
FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(1, 1), dtype=torch.int64))) FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(1, 1), dtype=torch.int64)))
FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(1, 1), dtype=torch.int64))) FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(1, 1), dtype=torch.int64)))
FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(1, 1), dtype=torch.int64))) FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(1, 1), dtype=torch.int64)))
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO] TRACED GRAPH
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]  ===== Forward graph 0 =====
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]  <eval_with_key>.4 from /Users/pierreguilmin/.pyenv/versions/live-compile-complex/lib/python3.9/site-packages/torch/fx/experimental/proxy_tensor.py:506 in wrapped class <lambda>(torch.nn.Module):
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]     def forward(self, arg0_1: i64[1, 1], arg1_1: i64[1, 1], arg2_1: i64[1, 1], arg3_1: i64[1, 1]):
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         # File: /Users/pierreguilmin/Desktop/live-compile-complex/foo.py:53, code: return x @ y
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         mul: i64[1, 1] = torch.ops.aten.mul.Tensor(arg0_1, arg2_1)
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         mul_1: i64[1, 1] = torch.ops.aten.mul.Tensor(arg1_1, arg3_1)
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         sub: i64[1, 1] = torch.ops.aten.sub.Tensor(mul, mul_1);  mul = mul_1 = None
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         mul_2: i64[1, 1] = torch.ops.aten.mul.Tensor(arg0_1, arg3_1);  arg0_1 = arg3_1 = None
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         mul_3: i64[1, 1] = torch.ops.aten.mul.Tensor(arg1_1, arg2_1);  arg1_1 = arg2_1 = None
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         add: i64[1, 1] = torch.ops.aten.add.Tensor(mul_2, mul_3);  mul_2 = mul_3 = None
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]         return [sub, add]
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]
[2023-10-17 11:32:12,381] [0/0] torch._functorch.aot_autograd.__aot_graphs: [INFO]
ComplexTensor(real=tensor([[-5]]), imag=tensor([[10]]))
```