### PR TITLE
Fix functorch import

### DIFF
--- a/run_test.py
+++ b/run_test.py
@@ -28,6 +28,7 @@ import torch
 from torch.testing._internal.common_utils import run_tests
 from bug_zoo import BugZoo
 from empty_tensor import EmptyTensorTest
+from functorch_test import FunctorchTest
 from inner_autograd_tensor import InnerAutogradTensorTest
 from logging_mode import TracerTensorTest
 from negative_tensor import NegativeTensorTest

--- a/run_test.py
+++ b/run_test.py
@@ -28,7 +28,6 @@ import torch
 from torch.testing._internal.common_utils import run_tests
 from bug_zoo import BugZoo
 from empty_tensor import EmptyTensorTest
-from functorch import FunctorchTest
 from inner_autograd_tensor import InnerAutogradTensorTest
 from logging_mode import TracerTensorTest
 from negative_tensor import NegativeTensorTest

--- a/tracer_tensor.py
+++ b/tracer_tensor.py
@@ -173,9 +173,9 @@ class TracerTensorTest(TestCase):
             str(g.graph),
             """\
 graph():
-    %arg_1 : [#users=1] = placeholder[target=arg_1]
-    %arg_2 : [#users=1] = placeholder[target=arg_2]
-    %add_tensor : [#users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%arg_1, %arg_2), kwargs = {})
+    %arg_1 : [num_users=1] = placeholder[target=arg_1]
+    %arg_2 : [num_users=1] = placeholder[target=arg_2]
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%arg_1, %arg_2), kwargs = {})
     return add_tensor""",
         )
 
@@ -186,9 +186,9 @@ graph():
             str(g.graph),
             """\
 graph():
-    %arg_1 : [#users=1] = placeholder[target=arg_1]
-    %_tensor_constant0 : [#users=1] = get_attr[target=_tensor_constant0]
-    %add_tensor : [#users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%_tensor_constant0, %arg_1), kwargs = {})
+    %arg_1 : [num_users=1] = placeholder[target=arg_1]
+    %_tensor_constant0 : [num_users=1] = get_attr[target=_tensor_constant0]
+    %add_tensor : [num_users=1] = call_function[target=torch.ops.aten.add.Tensor](args = (%_tensor_constant0, %arg_1), kwargs = {})
     return add_tensor""",
         )
 


### PR DESCRIPTION
CI in main is broken because the file was renamed to functorch_test - this also updates the test. Can't trigger CI signal but would be nice to do so before merge

```
Run python run_test.py
Fail to import hypothesis in common_utils, tests are not derandomized
Traceback (most recent call last):
  File "/home/runner/work/subclass_zoo/subclass_zoo/run_test.py", line 31, in <module>
    from functorch import FunctorchTest
ImportError: cannot import name 'FunctorchTest' from 'functorch' (/home/runner/.local/lib/python3.[10](https://github.com/albanD/subclass_zoo/actions/runs/8471184919/job/23210593635#step:6:11)/site-packages/functorch/__init__.py)
Error: Process completed with exit code 1.
```